### PR TITLE
Give direct access to Git::Base object

### DIFF
--- a/lib/gitmethere.rb
+++ b/lib/gitmethere.rb
@@ -6,7 +6,7 @@ module GitMeThere
 
   class Scenario
 
-    # All scenarios are automatically generated as a fresh repositorywith a README.md file
+    # All scenarios are automatically generated as a fresh repository with a README.md file
     # and an initial commit on the master branch.
     #
     # If an explanation is specified, it will be included as README.md text in the first commit.
@@ -19,6 +19,10 @@ module GitMeThere
     #   name: (String)
     #   explanation: (String)
     #
+
+    # Give direct access to the Git::Base object in a scenario
+    attr_accessor :g
+
     def initialize(name="my-scenario", explanation="")
       @name = name
       @g = Git.init(name)

--- a/spec/scenario_spec.rb
+++ b/spec/scenario_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe GitMeThere::Scenario do
 
   end
 
+  describe ".g" do
+
+    before(:each) do
+      @scenario = GitMeThere::Scenario.new()
+    end
+
+    it 'should return Git::Base object' do
+      expect(@scenario.g.class).to eq(Git::Base)
+    end
+
+  end
+
   describe ".create_file()" do
 
     before(:each) do


### PR DESCRIPTION
This Pull Request adds the functionality requested in #1.  It gives direct access to the `Git::Base` object within a Scenario object by way of the accessor `:g`.

It also includes a basic spec to ensure the attribute accessor returns a `Git::Base` object.
