### PR TITLE
Add the ability to commit as a different user

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ setup = {
 }
 
 scenario = GitMeThere::Scenario.new(name = setup[:name], explanation = setup[:explanation])
+other_author = GitMeThere::Author.new("Other Developer", "test@example.com")
 
 scenario.checkout_branch('feature')
 
@@ -38,7 +39,7 @@ scenario.append_to_file(
 
 scenario.stage_changes
 
-scenario.commit('Add line to feature branch.')
+scenario.commit('Add line to feature branch.', author=other_author)
 
 scenario.checkout_branch('master')
 

--- a/lib/gitmethere.rb
+++ b/lib/gitmethere.rb
@@ -1,4 +1,5 @@
 require "gitmethere/version"
+require "gitmethere/author"
 
 require 'git'
 
@@ -54,8 +55,12 @@ module GitMeThere
       end
     end
 
-    def commit(message)
-      @g.commit(message)
+    def commit(message, author = nil)
+      if author.nil?
+        @g.commit(message)
+      else
+        @g.commit(message, author: author.git_author)
+      end
     end
 
   end

--- a/lib/gitmethere/author.rb
+++ b/lib/gitmethere/author.rb
@@ -1,0 +1,14 @@
+module GitMeThere
+  class Author
+    attr_reader :name, :email
+
+    def initialize(name, email)
+      @name = name
+      @email = email
+    end
+
+    def git_author
+      "#{name} <#{email}>"
+    end
+  end
+end

--- a/spec/gitmethere/author_spec.rb
+++ b/spec/gitmethere/author_spec.rb
@@ -1,0 +1,27 @@
+require 'gitmethere'
+require 'fakefs/spec_helpers'
+
+RSpec.describe GitMeThere::Author do
+
+  before(:each) do
+    @author = GitMeThere::Author.new("Test User", "test@example.com")
+  end
+
+  describe ".new()" do
+
+    it "should create an author with the specified name and email" do
+      expect(@author.name).to eq("Test User")
+      expect(@author.email).to eq("test@example.com")
+    end
+
+  end
+
+  describe ".git_author()" do
+
+    it 'should return a valid git author identifier (name <email>)' do
+      expect(@author.git_author).to eq("Test User <test@example.com>")
+    end
+
+  end
+
+end

--- a/spec/scenario_spec.rb
+++ b/spec/scenario_spec.rb
@@ -161,6 +161,19 @@ RSpec.describe GitMeThere::Scenario do
       @scenario.commit("Testing the commit function")
       expect(@scenario.instance_variable_get(:@g).log.first.message).to eq("Testing the commit function")
     end
+
+    it "with message and author" do
+      author = GitMeThere::Author.new("Test User", "test@example.com")
+      @scenario.create_file(
+        name = "test-commit-file",
+        content = "commit this file."
+      )
+      @scenario.stage_changes
+      @scenario.commit("Testing the commit function with a different user", author)
+      expect(@scenario.instance_variable_get(:@g).log.first.message).to eq("Testing the commit function with a different user")
+      expect(@scenario.instance_variable_get(:@g).log.first.author.name).to eq(author.name)
+      expect(@scenario.instance_variable_get(:@g).log.first.author.email).to eq(author.email)
+    end
   end
 
   after(:each) do


### PR DESCRIPTION
This addresses #5 by adding an optional parameter to commit() that allow you to set the author for the commit.
