### PR TITLE
Add support for runtime pauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ other_author = GitMeThere::Author.new("Other Developer", "test@example.com")
 
 scenario.checkout_branch('feature')
 
+scenario.pause("Pausing between steps for an explanation...")
+
 scenario.append_to_file(
   file="README.md",
   content="A feature branch was created off of the `Initial commit`.

--- a/lib/gitmethere.rb
+++ b/lib/gitmethere.rb
@@ -2,6 +2,7 @@ require "gitmethere/version"
 require "gitmethere/author"
 
 require 'git'
+require 'io/console'
 
 module GitMeThere
 
@@ -61,6 +62,19 @@ module GitMeThere
       else
         @g.commit(message, author: author.git_author)
       end
+    end
+
+    def pause(message = nil)
+      STDIN.echo = false
+      if message
+        puts message
+      end
+      puts "Press any key to continue..."
+      input = STDIN.getch
+
+    ensure
+      STDIN.ioflush
+      STDIN.echo = true
     end
 
   end


### PR DESCRIPTION
This PR resolves #8 by adding basic support for runtime pauses via the `Scenario#pause` method.

This method also allows for an optional message to be displayed when pausing along with the default instruction to press any key.
