### PR TITLE
Improve semantics

### DIFF
--- a/lib/gitmethere.rb
+++ b/lib/gitmethere.rb
@@ -23,23 +23,23 @@ module GitMeThere
     #
 
     # Give direct access to the Git::Base object in a scenario
-    attr_accessor :g
+    attr_accessor :git
 
     def initialize(name="my-scenario", explanation="")
       @name = name
-      @g = Git.init(name)
+      @git = Git.init(name)
 
       self.create_file(name='README.md', content=explanation)
-      @g.add
-      @g.commit("Initial commit")
+      @git.add
+      @git.commit("Initial commit")
     end
 
     def checkout_branch(branch)
-      @g.branch(branch).checkout
+      @git.branch(branch).checkout
     end
 
     def stage_changes
-      @g.add
+      @git.add
     end
 
     def create_file(name="my-file.md", content="")
@@ -73,9 +73,9 @@ module GitMeThere
 
     def commit(message, author = nil)
       if author.nil?
-        @g.commit(message)
+        @git.commit(message)
       else
-        @g.commit(message, author: author.git_author)
+        @git.commit(message, author: author.git_author)
       end
     end
 

--- a/lib/gitmethere/version.rb
+++ b/lib/gitmethere/version.rb
@@ -1,3 +1,3 @@
 module Gitmethere
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/lib/gitmethere/version.rb
+++ b/lib/gitmethere/version.rb
@@ -1,3 +1,3 @@
 module Gitmethere
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/scenario_spec.rb
+++ b/spec/scenario_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe GitMeThere::Scenario do
 
   end
 
-  describe ".g" do
+  describe ".git" do
 
     before(:each) do
       @scenario = GitMeThere::Scenario.new()
     end
 
     it 'should return Git::Base object' do
-      expect(@scenario.g.class).to eq(Git::Base)
+      expect(@scenario.git.class).to eq(Git::Base)
     end
 
   end
@@ -172,13 +172,13 @@ RSpec.describe GitMeThere::Scenario do
 
     it "with new branch" do
       @scenario.checkout_branch("feature")
-      expect(@scenario.instance_variable_get(:@g).current_branch).to eq("feature")
+      expect(@scenario.instance_variable_get(:@git).current_branch).to eq("feature")
     end
 
     it "with existing branch" do
-      @scenario.instance_variable_get(:@g).branch("test-branch")
+      @scenario.instance_variable_get(:@git).branch("test-branch")
       @scenario.checkout_branch("test-branch")
-      expect(@scenario.instance_variable_get(:@g).current_branch).to eq("test-branch")
+      expect(@scenario.instance_variable_get(:@git).current_branch).to eq("test-branch")
     end
 
   end
@@ -198,7 +198,7 @@ RSpec.describe GitMeThere::Scenario do
         content = "Stage this file."
       )
       @scenario.stage_changes
-      expect(@scenario.instance_variable_get(:@g).status.added.keys).to include("test-staging-files.md")
+      expect(@scenario.instance_variable_get(:@git).status.added.keys).to include("test-staging-files.md")
     end
 
   end
@@ -218,7 +218,7 @@ RSpec.describe GitMeThere::Scenario do
       )
       @scenario.stage_changes
       @scenario.commit("Testing the commit function")
-      expect(@scenario.instance_variable_get(:@g).log.first.message).to eq("Testing the commit function")
+      expect(@scenario.instance_variable_get(:@git).log.first.message).to eq("Testing the commit function")
     end
 
     it "with message and author" do
@@ -229,9 +229,9 @@ RSpec.describe GitMeThere::Scenario do
       )
       @scenario.stage_changes
       @scenario.commit("Testing the commit function with a different user", author)
-      expect(@scenario.instance_variable_get(:@g).log.first.message).to eq("Testing the commit function with a different user")
-      expect(@scenario.instance_variable_get(:@g).log.first.author.name).to eq(author.name)
-      expect(@scenario.instance_variable_get(:@g).log.first.author.email).to eq(author.email)
+      expect(@scenario.instance_variable_get(:@git).log.first.message).to eq("Testing the commit function with a different user")
+      expect(@scenario.instance_variable_get(:@git).log.first.author.name).to eq(author.name)
+      expect(@scenario.instance_variable_get(:@git).log.first.author.email).to eq(author.email)
     end
   end
 


### PR DESCRIPTION
This PR changes the instance variable name for the scenario generator from `g` to `git` to be clearer.